### PR TITLE
Elapsed time always at the end of computation.

### DIFF
--- a/R/timerProgressBar.R
+++ b/R/timerProgressBar.R
@@ -7,9 +7,9 @@ width = NA, title, label, style = 1, file = "")
         stop("'file' must be \"\" or an open connection object")
     if (max <= min)
         stop("must have 'max' > 'min'")
-    if (!(style %in% 1:5))
+    if (!(style %in% 1:3))
         style <- 1
-    if (style %in% c(1, 2, 5))
+    if (style %in% c(1, 3))
         .counter <- force(1)
 
     .start <- proc.time()[["elapsed"]]
@@ -33,7 +33,17 @@ width = NA, title, label, style = 1, file = "")
         .i <<- value
         i <- .i - .min
         n <- .max - .min
-        time <- time / (i / n) - time
+
+        if(i != n)
+        {
+            time <- time / (i / n) - time
+            prefix = " ~"
+        } else
+        {
+            prefix = " Elapsed time: "
+        }
+
+
         if (i != 0)
             .counter <<- .counter + 1
         leftTime <- if (i == 0)
@@ -43,7 +53,7 @@ width = NA, title, label, style = 1, file = "")
         ## 79-24=55 > 50
         txtWidth <- max(width, width - minLetters - 4)
 
-        text <- paste0(sprintf("%-2.0f%%", 100 * i / n), " ~", leftTime)
+        text <- paste0(sprintf("%-2.0f%%", 100 * i / n), prefix, leftTime)
         if(nchar(text, "w") < minLetters)
             text <- paste(text, paste(rep(" ", minLetters - nchar(text, "w")),
                 collapse = ""))
@@ -54,7 +64,8 @@ width = NA, title, label, style = 1, file = "")
         cat(paste("\r", bar, text), file = file)
         flush.console()
     }
-    ## throbber with elapsed time
+
+    ## bar with remaining time
     up2 <- function(value) {
         if (!is.finite(value) || value < min || value > max)
             return()
@@ -62,37 +73,16 @@ width = NA, title, label, style = 1, file = "")
         .i <<- value
         i <- .i - .min
         n <- .max - .min
-        #time <- time / (i / n) - time
-        if (i != 0)
-            .counter <<- .counter + 1
-        #leftTime <- if (i == 0)
-        #    getTimeAsString(NULL) else getTimeAsString(time)
-        leftTime <- getTimeAsString(time)
-        minLetters <- nchar("%%%% ~00h 00m 00s", "w")
 
-        ## 79-24=55 > 50
-        txtWidth <- max(width, width - minLetters - 4)
+        if(i != n)
+        {
+            time <- time / (i / n) - time
+            prefix = " ~"
+        } else
+        {
+            prefix = " Elapsed time: "
+        }
 
-        text <- paste0(sprintf("%-2.0f%%", 100 * i / n), " =", leftTime)
-        if(nchar(text, "w") < minLetters)
-            text <- paste(text, paste(rep(" ", minLetters - nchar(text, "w")),
-                collapse = ""))
-        if(txtWidth < 0)
-            cat("\r ", text, file = file)
-        bb <- paste(rep(char, ceiling(txtWidth * i / n)), collapse = "")
-        bar <- c("|", "/", "-", "\\")[(.counter %% 4) + 1]
-        cat(paste("\r", bar, text), file = file)
-        flush.console()
-    }
-    ## bar with remaining time
-    up3 <- function(value) {
-        if (!is.finite(value) || value < min || value > max)
-            return()
-        time <- proc.time()[["elapsed"]] - .start
-        .i <<- value
-        i <- .i - .min
-        n <- .max - .min
-        time <- time / (i / n) - time
         leftTime <- if (i == 0)
             getTimeAsString(NULL) else getTimeAsString(time)
         #minLetters <- nchar("%%%.%%% ~00h 00m 00s", "w") # 2 decimals too much
@@ -101,37 +91,7 @@ width = NA, title, label, style = 1, file = "")
         ## 79-24=55 > 50
         txtWidth <- max(width, width - minLetters - 4)
 
-        #text <- paste0(sprintf("%-2.2f%%", 100 * i / n), " ~", leftTime)
-        text <- paste0(sprintf("%-2.0f%%", 100 * i / n), " ~", leftTime)
-        if(nchar(text, "w") < minLetters)
-            text <- paste(text, paste(rep(" ", minLetters - nchar(text, "w")),
-                collapse = ""))
-        if(txtWidth < 0)
-            cat("\r ", text, file = file)
-        bb <- paste(rep(char, ceiling(txtWidth * i / n)), collapse = "")
-        empty <- paste(rep(" ", floor(txtWidth * (1 - i / n))), collapse = "")
-        bar <- paste("  |", bb, empty, "|", sep = "")
-        cat(paste("\r", bar, text), file = file)
-        flush.console()
-    }
-    ## bar with elapsed time
-    up4 <- function(value) {
-        if (!is.finite(value) || value < min || value > max)
-            return()
-        time <- proc.time()[["elapsed"]] - .start
-        .i <<- value
-        i <- .i - .min
-        n <- .max - .min
-        #time <- time / (i / n) - time
-        #leftTime <- if (i == 0)
-        #    getTimeAsString(NULL) else getTimeAsString(time)
-        leftTime <- getTimeAsString(time)
-        minLetters <- nchar("%%%% ~00h 00m 00s", "w")
-
-        ## 79-24=55 > 50
-        txtWidth <- max(width, width - minLetters - 4)
-
-        text <- paste0(sprintf("%-2.0f%%", 100 * i / n), " =", leftTime)
+        text <- paste0(sprintf("%-2.0f%%", 100 * i / n), prefix, leftTime)
         if(nchar(text, "w") < minLetters)
             text <- paste(text, paste(rep(" ", minLetters - nchar(text, "w")),
                 collapse = ""))
@@ -144,7 +104,7 @@ width = NA, title, label, style = 1, file = "")
         flush.console()
     }
     ## throbber with elapsed and remaining time
-    up5 <- function(value) {
+    up3 <- function(value) {
         if (!is.finite(value) || value < min || value > max)
             return()
         time0 <- proc.time()[["elapsed"]] - .start
@@ -173,12 +133,13 @@ width = NA, title, label, style = 1, file = "")
         cat(paste("\r", bar, text), file = file)
         flush.console()
     }
+
     kill <- function() if (!.killed) {
         cat("\n", file = file)
         flush.console()
         .killed <<- TRUE
     }
-    up <- switch(style, up1, up2, up3, up4, up5)
+    up <- switch(style, up1, up2, up3)
     up(initial)
     structure(list(getVal = getVal, up = up, kill = kill),
         class = c("timerProgressBar","txtProgressBar"))

--- a/man/timerProgressBar.Rd
+++ b/man/timerProgressBar.Rd
@@ -33,12 +33,10 @@ If \code{NA}, the default, the number of characters is that
 which fits into \code{getOption("width")}.
 }
   \item{style}{
-the style taking values between 1 and 4.
+the style taking values between 1 and 3.
 1: throbber with remaining time,
-2: throbber with elapsed time,
-3: progress bar with remaining time,
-4: progress bar with elapsed time,
-5: throbber with elapsed and remaining time.
+2: progress bar with remaining time,
+3: throbber with elapsed and remaining time.
 }
   \item{file}{
 an open connection object or \code{""} which indicates the console.

--- a/man/timerProgressBar.Rd
+++ b/man/timerProgressBar.Rd
@@ -33,10 +33,11 @@ If \code{NA}, the default, the number of characters is that
 which fits into \code{getOption("width")}.
 }
   \item{style}{
-the style taking values between 1 and 3.
+the style taking values between 1 and 4.
 1: throbber with remaining time,
 2: progress bar with remaining time,
 3: throbber with elapsed and remaining time.
+4: progress bar with elapsed and remaining time.
 }
   \item{file}{
 an open connection object or \code{""} which indicates the console.


### PR DESCRIPTION
I think it would be better to if elapsed time will always be printed at the end of computation. In such case we could resign from progress bar and throbber with remaining time. Instead we can add progress bar with elapsed and remaining time.

```r
pboptions(style=2)
a = pblapply(runif(10,0,2), Sys.sleep)
   |++++++++++++++++++++++++++++++++++++++++++++++++++| 100% Elapsed time: 09s

 pboptions(style=4)
 a = pblapply(runif(10,0,0.2), Sys.sleep)
   |++++++++++++++++++++++++++++++++++++++++++++++++++| 100%  elapsed =01s, remaining ~00s

```


