### PR TITLE
Add day formatting

### DIFF
--- a/R/timerProgressBar.R
+++ b/R/timerProgressBar.R
@@ -184,11 +184,15 @@ getTimeAsString <- function(time) {
     time <- floor(time / 60)
     minutes <- floor(time %% 60)
     time <- floor(time / 60)
-    hours <- time
+    days <- floor(time / 24)
+    time <- floor(time %% 24)
+    hours <- floor(time %% 60)
     resTime <- ""
-    if (hours > 0)
-        resTime <- sprintf("%02ih ", hours)
-    if (minutes > 0 || hours > 0)
+    if (days > 0)
+        resTime <- sprintf("%02id ", days)
+    if (hours > 0 || days > 0)
+        resTime <- paste(resTime, sprintf("%02ih ", hours), sep = "")
+    if (minutes > 0 || hours > 0 || days > 0)
         resTime <- paste(resTime, sprintf("%02im ", minutes), sep = "")
     resTime <- paste0(resTime, sprintf("%02is", sec))
     resTime


### PR DESCRIPTION
I would like to add `pbapply` as a dependency to one of my packages (specifically after the a version which supports parallel computations is released to CRAN). However, I was wondering if you could add a `days` formatting to the progress output. Some of my apply statements could take days to finish, therefore I would prefer to print the number of days and hours instead of just the hours alone. 

The following pull request gives this type of output:

```r
> getTimeAsString(60)
[1] "01m 00s"
> getTimeAsString(60 * 60)
[1] "01h 00m 00s"
> getTimeAsString(60 * 60 * 24)
[1] "01d 00h 00m 00s"
> getTimeAsString(60 * 60 * 24 * 4)
[1] "04d 00h 00m 00s"
> getTimeAsString(60 * 60 * 24 * 4 + 1)
[1] "04d 00h 00m 01s"
```